### PR TITLE
Pin GHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
       ENDOR_NAMESPACE: "yolo"
     steps:
       - name: Clone Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: Setup JDK with Maven
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           distribution: microsoft
           java-version: 17
@@ -34,7 +34,7 @@ jobs:
 
       - name: Endor Labs Scan
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: ${{ env.ENDOR_NAMESPACE }}
           pr: "false"
@@ -43,7 +43,7 @@ jobs:
           
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: ${{ env.ENDOR_NAMESPACE }}
           pr: true
@@ -53,7 +53,7 @@ jobs:
           additional_args: "--output-type=summary"
 
       - name: Upload SARIF to github
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         with:
           sarif_file: endor-labs.sarif
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Sign Docker Image with Endor Labs
         if: ${{ steps.dockerbuild.outcome == 'success' }}
-        uses: endorlabs/github-action/sign@main
+        uses: endorlabs/github-action/sign@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: ${{ env.ENDOR_NAMESPACE }}
           artifact_name: ${{ steps.dockerbuild.outputs.image_id }}
@@ -74,7 +74,7 @@ jobs:
       # PUBLISH IMAGE HERE -- avoiding due to demo repo
         
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: endorlabs-java-webapp-demo
           path: |


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                  
  Pin all GitHub Actions to full commit SHAs to prevent supply chain attacks from compromised tags.                                                                               
                                                                                                                                                                                  
  ## Changes                                                                                                                                                                      
                                                                                                                                                                                
  | Action | Old Ref | New Ref | SHA |                                                                                                                                            
  |--------|---------|---------|-----|
  | actions/checkout | v3 | v3.6.0 | [f43a0e5](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744) |                                             
  | actions/setup-java | v3 | v3.14.1 | [17f84c3](https://github.com/actions/setup-java/commit/17f84c3641ba7b8f6deff6309fc4c864478f5d62) |                                        
  | endorlabs/github-action | main | v1.1.9 | [0223126](https://github.com/endorlabs/github-action/commit/02231267f2d7d3be21f10662fdd39fba143d4bda) |                             
  | endorlabs/github-action/sign | main | v1.1.9 | [0223126](https://github.com/endorlabs/github-action/commit/02231267f2d7d3be21f10662fdd39fba143d4bda) |                        
  | github/codeql-action/upload-sarif | v3 | v3.31.9 | [45c3735](https://github.com/github/codeql-action/commit/45c373516f557556c15d420e3f5e0aa3d64366bc) |                       
  | actions/upload-artifact | v4 | v4.6.2 | [ea165f8](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02) |                               
                                                                                                                                                                                  
  All pinned commits are at least 90 days old. Original version tags are preserved as inline comments for maintainability.                                                        
                                                                                                                                                                                  
  **Notes:**                                                                                                                                                                      
  - `endorlabs/github-action@main` was pinned to v1.1.9 (v1.1.11 was only 26 days old)                                                                                          
  - `github/codeql-action@v3` was pinned to v3.31.9 (v3.34.1 was only 4 days old)                                                                                                 
                                                                                                                                                                                  
  **Files modified:**                                                                                                                                                             
  - `.github/workflows/main.yml` — pinned all 7 action references to commit SHAs  